### PR TITLE
Добавлены пакеты Accord.Net

### DIFF
--- a/agario/dockers/c_sharp/Dockerfile
+++ b/agario/dockers/c_sharp/Dockerfile
@@ -3,16 +3,38 @@ MAINTAINER Boris Kolganov <b.kolganov@corp.mail.ru>
 
 ENV MONO_GC_PARAMS max-heap-size=256M
 
-ENV SOLUTION_CODE_ENTRYPOINT=main.cs
 ENV COMPILED_FILE_PATH=/opt/client/csharpStrategy
-ENV COMPILATION_COMMAND='csc /reference:Newtonsoft.Json.dll `find $SOLUTION_CODE_PATH -name "*.cs"` -out:$COMPILED_FILE_PATH'
-ENV RUN_COMMAND='mono $MOUNT_POINT'
+
+ENV NUGET_PACKAGES_DIR=./pkgs/
+ENV NUGET_FILE_PATH=./nuget.exe
+ENV NUGET_PACKAGES_CONFIG=./packages.config
+
+ENV COMPILATION_COMMAND='csc $(find $NUGET_PACKAGES_DIR -wholename "*/net45/*.dll"  -exec echo "/reference:{}" \; | tr "\n" " " ) $(find $SOLUTION_CODE_PATH -name "*.cs") -out:$COMPILED_FILE_PATH'
+
+ENV RUN_COMMAND='export MONO_PATH=$LD_LIBRARY_PATH:$(find $NUGET_PACKAGES_DIR -wholename "*/net45/*.dll"  -printf "%h/\n" | tr "\n" ":" ) && mono $MOUNT_POINT'
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+RUN apt-get update && apt-get install -y wget
+
 RUN echo "deb http://download.mono-project.com/repo/ubuntu stable-trusty main" > /etc/apt/sources.list.d/mono-official-stable.list && \
     apt-get update && \
     apt-get install -y mono-complete zip && \
     rm -rf /var/lib/apt/lists/* /tmp/* && \
     export MONO_GC_PARAMS=max-heap-size=256M
 
-COPY Newtonsoft.Json.dll ./
+RUN bash -c "$(/bin/echo -e "cat > $NUGET_PACKAGES_CONFIG <<EOM\
+    \n<?xml version=\"1.0\" encoding=\"utf-8\"?> \
+    \n<packages> \
+    \n    <package id=\"Accord\" version=\"3.8.0\" targetFramework=\"net45\" /> \
+    \n    <package id=\"Accord.Genetic\" version=\"3.8.0\" targetFramework=\"net45\" /> \
+    \n    <package id=\"Accord.MachineLearning\" version=\"3.8.0\" targetFramework=\"net45\" /> \
+    \n    <package id=\"Accord.Math\" version=\"3.8.0\" targetFramework=\"net45\" /> \
+    \n    <package id=\"Accord.Neuro\" version=\"3.8.0\" targetFramework=\"net45\" /> \
+    \n    <package id=\"Accord.Statistics\" version=\"3.8.0\" targetFramework=\"net45\" /> \
+    \n    <package id=\"Newtonsoft.Json\" version=\"11.0.2\" targetFramework=\"net45\" /> \
+    \n</packages> \
+    \nEOM\n")"
+
+RUN wget https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -O $NUGET_FILE_PATH && \
+    cat packages.config &&\
+    mono $NUGET_FILE_PATH install $NUGET_PACKAGES_CONFIG  -OutputDirectory $NUGET_PACKAGES_DIR


### PR DESCRIPTION
Реализация решения задачи [CSharp .NET: Добавление библиотеки accord-net framework](https://github.com/MailRuChamps/miniaicups/issues/75) #75 путем изменения одного файла.

**Файл протестирован следующим образом:**

*Сборка*:
`sudo docker build -t cs/b:latest ./`

*Тестирование* (при наличии хотя бы одного `.cs` файла в `$SOLUTION_CODE_PATH` )
 `sudo docker run -e MOUNT_POINT=/opt/client/csharpStrategy -e SOLUTION_CODE_PATH='/opt/client/'  -v ~/csharp/code:/opt/client/code  -v ~/csharp/release:/opt/client/ cs/b bash -c "eval \$COMPILATION_COMMAND"`

вывод:

```
Microsoft (R) Visual C# Compiler version 2.6.0.62309 (d3f6b8e7)
Copyright (C) Microsoft Corporation. All rights reserved.
```

*Запуск*
` sudo docker run -it -e MOUNT_POINT=/opt/client/csharpStrategy -e SOLUTION_CODE_PATH='/opt/client/'  -v ~/csharp/code:/opt/client/code  -v ~/csharp/release:/opt/client/ cs/b bash -c "eval \$RUN_COMMAND"` корректно получает\интерпретирует ввод

**Замечания**
 Q: Почему существующего `main.cs` достаточно для тестирования?
 A: Потому что все пакеты включая Newtonsoft.Json устанавливаются пакетным менеджером

 Q: Что надо чтобы добавить еще один пакет представленный в NuGet?
 A:  Дописать строку аналогичную `\n    <package id=\"Accord.MachineLearning\" version=\"3.8.0\" targetFramework=\"net45\" /> \` содержащую имя пакета в NuGet

 Q: Что надо чтобы форсировать все библиотеки из .NET 3.5
 A; заменить все `net45` на `net35`